### PR TITLE
[feat] 게시글의 좋아요 기능을 구현한다

### DIFF
--- a/src/main/java/com/puppy/pawpaw_project_be/domain/board/controller/BoardLikeRestController.java
+++ b/src/main/java/com/puppy/pawpaw_project_be/domain/board/controller/BoardLikeRestController.java
@@ -1,0 +1,26 @@
+package com.puppy.pawpaw_project_be.domain.board.controller;
+
+import com.puppy.pawpaw_project_be.config.annotation.AuthenticatedUserId;
+import com.puppy.pawpaw_project_be.domain.board.service.BoardLikeService;
+import com.puppy.pawpaw_project_be.domain.user.domain.UserId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/boardLike")
+public class BoardLikeRestController {
+
+    private final BoardLikeService boardLikeService;
+
+    @PostMapping("/like")
+    public ResponseEntity addOrDeleteLike(@RequestParam Long boardId, @AuthenticatedUserId UserId userId){
+        boolean result = boardLikeService.addOrDeleteLike(boardId, userId);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/puppy/pawpaw_project_be/domain/board/dto/BoardDto.java
+++ b/src/main/java/com/puppy/pawpaw_project_be/domain/board/dto/BoardDto.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
-@Getter
+
 public class BoardDto {
 
     @Getter

--- a/src/main/java/com/puppy/pawpaw_project_be/domain/board/entity/Board.java
+++ b/src/main/java/com/puppy/pawpaw_project_be/domain/board/entity/Board.java
@@ -9,6 +9,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
 
 @Entity
 @Getter
@@ -46,6 +48,9 @@ public final class Board {
     @Column
     private LocalDateTime updatedAt = LocalDateTime.now();
 
+    @OneToMany(mappedBy = "board", orphanRemoval = true)
+    private Set<BoardLikes> boardLikes = new HashSet<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
@@ -77,14 +82,7 @@ public final class Board {
     }
 
 
-    public void updateTitle(String title){
-        this.title = title;
-    }
-    public void updateContent(String content){
-        this.content = content;
-    }
-
-    public void updateBoard(String title, String content){
+    public void updateTitleAndContent(String title, String content){
         this.title = title;
         this.content = content;
     }
@@ -92,5 +90,4 @@ public final class Board {
     public void remove() {
         this.isRemoved = true;
     }
-
 }

--- a/src/main/java/com/puppy/pawpaw_project_be/domain/board/entity/Board.java
+++ b/src/main/java/com/puppy/pawpaw_project_be/domain/board/entity/Board.java
@@ -69,6 +69,13 @@ public final class Board {
         return board;
     }
 
+    public void plusLikedCount(){
+        this.likedCount = likedCount +1;
+    }
+    public void minusLikedCount(){
+        this.likedCount = likedCount - 1;
+    }
+
 
     public void updateTitle(String title){
         this.title = title;

--- a/src/main/java/com/puppy/pawpaw_project_be/domain/board/entity/BoardLikes.java
+++ b/src/main/java/com/puppy/pawpaw_project_be/domain/board/entity/BoardLikes.java
@@ -1,0 +1,32 @@
+package com.puppy.pawpaw_project_be.domain.board.entity;
+
+import com.puppy.pawpaw_project_be.domain.user.domain.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class BoardLikes {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "boardLikes_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
+
+
+    public BoardLikes(User user, Board board) {
+        this.user = user;
+        this.board = board;
+    }
+}

--- a/src/main/java/com/puppy/pawpaw_project_be/domain/board/repository/BoardLikesRepository.java
+++ b/src/main/java/com/puppy/pawpaw_project_be/domain/board/repository/BoardLikesRepository.java
@@ -1,0 +1,15 @@
+package com.puppy.pawpaw_project_be.domain.board.repository;
+
+import com.puppy.pawpaw_project_be.domain.board.entity.Board;
+import com.puppy.pawpaw_project_be.domain.board.entity.BoardLikes;
+import com.puppy.pawpaw_project_be.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BoardLikesRepository extends JpaRepository<BoardLikes, Long> {
+
+    Optional<BoardLikes> deleteBoardLikesByUserAndBoard(User user, Board board);
+    Optional<BoardLikes> findByUserAndBoard(User user, Board board);
+
+}

--- a/src/main/java/com/puppy/pawpaw_project_be/domain/board/service/BoardLikeService.java
+++ b/src/main/java/com/puppy/pawpaw_project_be/domain/board/service/BoardLikeService.java
@@ -1,0 +1,43 @@
+package com.puppy.pawpaw_project_be.domain.board.service;
+
+import com.puppy.pawpaw_project_be.domain.board.entity.Board;
+import com.puppy.pawpaw_project_be.domain.board.entity.BoardLikes;
+import com.puppy.pawpaw_project_be.domain.board.repository.BoardLikesRepository;
+import com.puppy.pawpaw_project_be.domain.board.repository.BoardRepository;
+import com.puppy.pawpaw_project_be.domain.user.domain.User;
+import com.puppy.pawpaw_project_be.domain.user.domain.UserId;
+import com.puppy.pawpaw_project_be.domain.user.domain.repository.UserRepository;
+import com.puppy.pawpaw_project_be.exception.user.NotFoundUserException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityNotFoundException;
+
+@Service
+@RequiredArgsConstructor
+public class BoardLikeService {
+
+    private final BoardLikesRepository likesRepository;
+    private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
+
+    @Transactional
+    public boolean addOrDeleteLike(Long boardId, UserId userId){
+        Board board = boardRepository.findById(boardId).orElseThrow(EntityNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(NotFoundUserException::new);
+        if (likesNotExist(user, board)){
+           likesRepository.save(new BoardLikes(user, board));
+           board.plusLikedCount();
+            return true;
+        }else {
+            likesRepository.deleteBoardLikesByUserAndBoard(user, board);
+            board.minusLikedCount();
+            return false;
+        }
+    }
+
+    private boolean likesNotExist(User user, Board board){
+        return likesRepository.findByUserAndBoard(user, board).isEmpty();  // 좋아요가 없으면 true
+    }
+}

--- a/src/main/java/com/puppy/pawpaw_project_be/domain/board/service/BoardService.java
+++ b/src/main/java/com/puppy/pawpaw_project_be/domain/board/service/BoardService.java
@@ -1,6 +1,5 @@
 package com.puppy.pawpaw_project_be.domain.board.service;
 
-import com.puppy.pawpaw_project_be.domain.board.dto.BoardDto;
 import com.puppy.pawpaw_project_be.domain.board.dto.BoardDto.BoardRegisterDto;
 import com.puppy.pawpaw_project_be.domain.board.dto.BoardDto.BoardResponseDto;
 import com.puppy.pawpaw_project_be.domain.board.dto.BoardDto.BoardUpdateDto;
@@ -11,9 +10,6 @@ import com.puppy.pawpaw_project_be.domain.user.domain.UserId;
 import com.puppy.pawpaw_project_be.domain.user.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -54,16 +50,16 @@ public class BoardService {
 
         User user = userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
         Board board = boardRepository.findById(id).orElseThrow(EntityNotFoundException::new);
-        if (user.getUserId() != board.getUser().getUserId()){
+        if (user.getUserId() != board.getUser().getUserId()) {
             return null;
         }
 
-        if (updateDto.getTitle() != null) {
-            board.updateTitle(updateDto.getTitle());
+        if (updateDto.getTitle() != null || updateDto.getContent() != null){
+            board.updateTitleAndContent(updateDto.getTitle(), updateDto.getContent());
         }
-        if (updateDto.getContent() != null) {
-            board.updateContent(updateDto.getContent());
-        }
+
+
+
 
         return BoardUpdateDto.builder()
                 .title(board.getTitle())
@@ -78,7 +74,7 @@ public class BoardService {
 
         User user = userRepository.findById(userId).orElseThrow(EntityNotFoundException::new);
         Board board = boardRepository.findById(id).orElseThrow(EntityNotFoundException::new);
-        if (user.getUserId() != board.getUser().getUserId()){
+        if (user.getUserId() != board.getUser().getUserId()) {
 
         }
         boardRepository.delete(board);


### PR DESCRIPTION
## Motivation
1. 피드에 올라온 게시글의 좋아요 추가 및 좋아요 취소 기능을 구현한다.
2. 게시글과 좋아요 간의 연관관계를 추가하고 updateBoard 메서드의 이름을 변경한다.
3. BoardDto 클래스에 불필요한 @getter[을 삭제한다
