### PR TITLE
Fix: 채팅방 메시지 유형 추가 및  메시지 전송 추가

### DIFF
--- a/api/src/main/java/kr/co/pawpaw/api/service/chatroom/ChatroomService.java
+++ b/api/src/main/java/kr/co/pawpaw/api/service/chatroom/ChatroomService.java
@@ -98,6 +98,8 @@ public class ChatroomService {
             .orElseThrow(NotFoundChatroomException::new);
 
         chatroom.updateManager(nextManager);
+
+        saveAndPublishChatMessage(ChatType.CHANGE_MANAGER, ChatUtil.getChangeManagerDataFromNickname(nextManager.getUser().getNickname()), chatroomId);
     }
 
     @Transactional(readOnly = true)
@@ -141,9 +143,12 @@ public class ChatroomService {
         final Long chatroomId,
         final InviteChatroomUserRequest request
     ) {
-        checkAlreadyChatroomParticipant(chatroomId, request.getUserId());
+        User user = userQuery.findByUserId(request.getUserId())
+            .orElseThrow(NotFoundUserException::new);
 
+        checkAlreadyChatroomParticipant(chatroomId, request.getUserId());
         createChatroomParticipantByChatroomIdAndInviteChatroomUserRequest(chatroomId, request);
+        saveAndPublishChatMessage(ChatType.INVITE, ChatUtil.getInviteDataFromNickname(user.getNickname()), chatroomId);
     }
 
     @Transactional

--- a/api/src/test/java/kr/co/pawpaw/api/service/chatroom/ChatroomServiceTest.java
+++ b/api/src/test/java/kr/co/pawpaw/api/service/chatroom/ChatroomServiceTest.java
@@ -10,6 +10,7 @@ import kr.co.pawpaw.dynamodb.chat.domain.ChatType;
 import kr.co.pawpaw.dynamodb.chat.dto.ChatMessageDto;
 import kr.co.pawpaw.dynamodb.chat.service.command.ChatCommand;
 import kr.co.pawpaw.dynamodb.chat.service.query.ChatQuery;
+import kr.co.pawpaw.dynamodb.util.chat.ChatUtil;
 import kr.co.pawpaw.mysql.chatroom.domain.*;
 import kr.co.pawpaw.mysql.chatroom.dto.*;
 import kr.co.pawpaw.mysql.chatroom.service.command.ChatroomCommand;
@@ -126,7 +127,7 @@ class ChatroomServiceTest {
     static void setup() throws NoSuchFieldException, IllegalAccessException {
         Field idField = Chatroom.class.getDeclaredField("id");
         idField.setAccessible(true);
-        idField.set(chatroom, 12345L);
+        idField.set(chatroom, 123L);
     }
 
     @Nested
@@ -172,15 +173,21 @@ class ChatroomServiceTest {
     @DisplayName("updateChatroomManager 메서드는")
     class UpdateChatroomManager {
         Long chatroomId = 123L;
-        User user1 = User.builder().build();
-        User user2 = User.builder().build();
+        User user1 = User.builder()
+            .nickname("user1-nickname")
+            .build();
+        User user2 = User.builder()
+            .nickname("user2-nickname")
+            .build();
 
         ChatroomParticipant currentManager = ChatroomParticipant.builder()
             .role(ChatroomParticipantRole.MANAGER)
+            .user(user1)
             .build();
 
         ChatroomParticipant nextManager = ChatroomParticipant.builder()
             .role(ChatroomParticipantRole.PARTICIPANT)
+            .user(user2)
             .build();
 
         UpdateChatroomManagerRequest request1 = UpdateChatroomManagerRequest.builder()
@@ -191,6 +198,12 @@ class ChatroomServiceTest {
             .nextManagerId(user1.getUserId())
             .build();
 
+        Chat chat = Chat.builder()
+            .chatroomId(chatroomId)
+            .chatType(ChatType.CHANGE_MANAGER)
+            .data(ChatUtil.getChangeManagerDataFromNickname(nextManager.getUser().getNickname()))
+            .build();
+
         @Test
         @DisplayName("채팅방 참여자가 아니면 예외가 발생한다.")
         void ifNotAChatroomParticipantThenThrowException() {
@@ -198,11 +211,9 @@ class ChatroomServiceTest {
             when(chatroomParticipantQuery.findByUserIdAndChatroomId(user1.getUserId(), chatroomId)).thenReturn(Optional.empty());
             when(chatroomParticipantQuery.findByUserIdAndChatroomId(user2.getUserId(), chatroomId)).thenReturn(Optional.empty());
 
-            //when
+            //then
             assertThatThrownBy(() -> chatroomService.updateChatroomManager(user1.getUserId(), chatroomId, request1)).isInstanceOf(NotAChatroomParticipantException.class);
             assertThatThrownBy(() -> chatroomService.updateChatroomManager(user2.getUserId(), chatroomId, request2)).isInstanceOf(NotAChatroomParticipantException.class);
-
-            //then
         }
 
         @Test
@@ -211,12 +222,9 @@ class ChatroomServiceTest {
             //given
             when(chatroomParticipantQuery.findByUserIdAndChatroomId(user1.getUserId(), chatroomId)).thenReturn(Optional.of(currentManager));
 
-            //when
+            //then
             assertThatThrownBy(() -> chatroomService.updateChatroomManager(user1.getUserId(), chatroomId, request2))
                 .isInstanceOf(AlreadyChatroomManagerException.class);
-
-            //then
-
         }
 
         @Test
@@ -227,12 +235,9 @@ class ChatroomServiceTest {
             when(chatroomParticipantQuery.findByUserIdAndChatroomId(user2.getUserId(), chatroomId)).thenReturn(Optional.of(nextManager));
             when(chatroomQuery.findById(chatroomId)).thenReturn(Optional.empty());
 
-            //when
+            //then
             assertThatThrownBy(() -> chatroomService.updateChatroomManager(user1.getUserId(), chatroomId, request1))
                 .isInstanceOf(NotFoundChatroomException.class);
-
-            //then
-
         }
 
         @Test
@@ -242,6 +247,7 @@ class ChatroomServiceTest {
             when(chatroomParticipantQuery.findByUserIdAndChatroomId(user1.getUserId(), chatroomId)).thenReturn(Optional.of(currentManager));
             when(chatroomParticipantQuery.findByUserIdAndChatroomId(user2.getUserId(), chatroomId)).thenReturn(Optional.of(nextManager));
             when(chatroomQuery.findById(chatroomId)).thenReturn(Optional.of(chatroom));
+            when(chatCommand.save(any(Chat.class))).thenReturn(chat);
 
             //when
             chatroomService.updateChatroomManager(user1.getUserId(), chatroomId, request1);
@@ -258,12 +264,42 @@ class ChatroomServiceTest {
             when(chatroomParticipantQuery.findByUserIdAndChatroomId(user1.getUserId(), chatroomId)).thenReturn(Optional.of(currentManager));
             when(chatroomParticipantQuery.findByUserIdAndChatroomId(user2.getUserId(), chatroomId)).thenReturn(Optional.of(nextManager));
             when(chatroomQuery.findById(chatroomId)).thenReturn(Optional.of(chatroom));
+            when(chatCommand.save(any(Chat.class))).thenReturn(chat);
 
             //when
             chatroomService.updateChatroomManager(user1.getUserId(), chatroomId, request1);
 
             //then
             assertThat(chatroom.getManager()).usingRecursiveComparison().isEqualTo(nextManager);
+        }
+
+        @Test
+        @DisplayName("방장 변경 유형의 채팅을 저장하고 채팅방에 메시지를 전송한다.")
+        void saveChatAndPublish() {
+            //given
+            when(chatroomParticipantQuery.findByUserIdAndChatroomId(user1.getUserId(), chatroomId)).thenReturn(Optional.of(currentManager));
+            when(chatroomParticipantQuery.findByUserIdAndChatroomId(user2.getUserId(), chatroomId)).thenReturn(Optional.of(nextManager));
+            when(chatroomQuery.findById(chatroomId)).thenReturn(Optional.of(chatroom));
+            when(chatCommand.save(any(Chat.class))).thenReturn(chat);
+
+            //when
+            chatroomService.updateChatroomManager(user1.getUserId(), chatroomId, request1);
+
+            //then
+            ArgumentCaptor<Chat> chatArgumentCaptor = ArgumentCaptor.forClass(Chat.class);
+            verify(chatCommand).save(chatArgumentCaptor.capture());
+            assertThat(chatArgumentCaptor.getValue()).usingRecursiveComparison()
+                .ignoringFields("chatId.sortId")
+                .isEqualTo(Chat.builder()
+                    .chatroomId(chatroom.getId())
+                    .chatType(ChatType.CHANGE_MANAGER)
+                    .data(ChatUtil.getChangeManagerDataFromNickname(nextManager.getUser().getNickname()))
+                .build());
+
+            ArgumentCaptor<ChatMessageDto> chatMessageDtoArgumentCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+            verify(redisPublisher).publish(eq(channelTopic), chatMessageDtoArgumentCaptor.capture());
+            assertThat(chatMessageDtoArgumentCaptor.getValue()).usingRecursiveComparison()
+                .isEqualTo(ChatMessageDto.of(chat, null, null));
         }
     }
 
@@ -319,11 +355,9 @@ class ChatroomServiceTest {
             //given
             when(userQuery.findByUserId(user.getUserId())).thenReturn(Optional.empty());
 
-            //when
+            //then
             assertThatThrownBy(() -> chatroomService.sendChatImage(user.getUserId(), chatroomId, multipartFile))
                 .isInstanceOf(NotFoundUserException.class);
-
-            //then
         }
 
         @Test
@@ -898,9 +932,6 @@ class ChatroomServiceTest {
     @Nested
     @DisplayName("inviteUser 메서드는")
     class InviteUser {
-        private InviteChatroomUserRequest request = InviteChatroomUserRequest.builder()
-            .userId(UserId.create())
-            .build();
         private Long chatroomId = 123L;
         private Chatroom chatroom = Chatroom.builder()
             .name("chatroom-name")
@@ -917,6 +948,9 @@ class ChatroomServiceTest {
             .briefIntroduction("user-briefIntroduction")
             .phoneNumber("user-phoneNumber")
             .build();
+        private InviteChatroomUserRequest request = InviteChatroomUserRequest.builder()
+            .userId(user.getUserId())
+            .build();
         private ChatroomParticipant chatroomParticipant = ChatroomParticipant.builder()
             .chatroom(chatroom)
             .user(user)
@@ -924,25 +958,37 @@ class ChatroomServiceTest {
             .build();
 
         @Test
+        @DisplayName("존재하지 않는 유저를 초대하면 예외가 발생한다.")
+        void NotFoundUserException() {
+            //given
+            when(userQuery.findByUserId(request.getUserId())).thenReturn(Optional.empty());
+
+            //then
+            assertThatThrownBy(() -> chatroomService.inviteUser(chatroomId, request))
+                .isInstanceOf(NotFoundUserException.class);
+        }
+
+        @Test
         @DisplayName("이미 참여한 유저를 초대하면 예외가 발생한다.")
         void AlreadyChatroomParticipantException() {
             //given
+            when(userQuery.findByUserId(request.getUserId())).thenReturn(Optional.of(user));
             when(chatroomParticipantQuery.existsByUserIdAndChatroomId(request.getUserId(), chatroomId)).thenReturn(true);
 
-            //when
+            //then
             assertThatThrownBy(() -> chatroomService.inviteUser(chatroomId, request))
                 .isInstanceOf(AlreadyChatroomParticipantException.class);
-
-            //then
         }
 
         @Test
         @DisplayName("ChatroomParticipantCommand의 save메서드를 호출한다.")
         void callSaveMethod() {
             //given
+            when(userQuery.findByUserId(request.getUserId())).thenReturn(Optional.of(user));
             when(chatroomParticipantQuery.existsByUserIdAndChatroomId(request.getUserId(), chatroomId)).thenReturn(false);
             when(chatroomQuery.getReferenceById(chatroomId)).thenReturn(chatroom);
             when(userQuery.getReferenceById(request.getUserId())).thenReturn(user);
+            when(chatCommand.save(any(Chat.class))).thenReturn(chat);
 
             //when
             chatroomService.inviteUser(chatroomId, request);
@@ -950,7 +996,36 @@ class ChatroomServiceTest {
             //then
             ArgumentCaptor<ChatroomParticipant> captor = ArgumentCaptor.forClass(ChatroomParticipant.class);
             verify(chatroomParticipantCommand).save(captor.capture());
-            assertThat(chatroomParticipant).usingRecursiveComparison().isEqualTo(captor.getValue());
+            assertThat(captor.getValue()).usingRecursiveComparison().isEqualTo(chatroomParticipant);
+        }
+
+        @Test
+        @DisplayName("chatCommand의 save 메서드를 통해 invite 유형의 chat을 저장하고 redisPublisher의 publish를 호출하여 채팅방에 메시지를 전송한다.")
+        void saveChatAndPublishInviteMessage() {
+            //given
+            when(userQuery.findByUserId(request.getUserId())).thenReturn(Optional.of(user));
+            when(chatroomParticipantQuery.existsByUserIdAndChatroomId(request.getUserId(), chatroomId)).thenReturn(false);
+            when(chatroomQuery.getReferenceById(chatroomId)).thenReturn(chatroom);
+            when(userQuery.getReferenceById(request.getUserId())).thenReturn(user);
+            when(chatCommand.save(any(Chat.class))).thenReturn(chat);
+
+            //when
+            chatroomService.inviteUser(chatroomId, request);
+
+            //then
+            ArgumentCaptor<Chat> argumentCaptor = ArgumentCaptor.forClass(Chat.class);
+            verify(chatCommand).save(argumentCaptor.capture());
+            assertThat(argumentCaptor.getValue()).usingRecursiveComparison()
+                .ignoringFields("chatId.sortId")
+                .isEqualTo(Chat.builder()
+                    .chatroomId(chatroomId)
+                    .chatType(ChatType.INVITE)
+                    .data(ChatUtil.getInviteDataFromNickname(user.getNickname()))
+                    .build());
+            ArgumentCaptor<ChatMessageDto> chatMessageDtoArgumentCaptor = ArgumentCaptor.forClass(ChatMessageDto.class);
+            verify(redisPublisher).publish(eq(channelTopic), chatMessageDtoArgumentCaptor.capture());
+            assertThat(chatMessageDtoArgumentCaptor.getValue()).usingRecursiveComparison()
+                .isEqualTo(ChatMessageDto.of(chat, null, null));
         }
     }
 }

--- a/domain/dynamodb/src/main/java/kr/co/pawpaw/dynamodb/chat/domain/ChatType.java
+++ b/domain/dynamodb/src/main/java/kr/co/pawpaw/dynamodb/chat/domain/ChatType.java
@@ -4,5 +4,7 @@ public enum ChatType {
     MESSAGE,
     IMAGE,
     JOIN,
-    LEAVE
+    LEAVE,
+    INVITE,
+    CHANGE_MANAGER
 }

--- a/domain/dynamodb/src/main/java/kr/co/pawpaw/dynamodb/util/chat/ChatUtil.java
+++ b/domain/dynamodb/src/main/java/kr/co/pawpaw/dynamodb/util/chat/ChatUtil.java
@@ -35,4 +35,11 @@ public class ChatUtil {
         return String.format("%s님이 퇴장하셨습니다.", nickname);
     }
 
+    public String getInviteDataFromNickname(final String nickname) {
+        return String.format("%s님이 초대되었습니다.", nickname);
+    }
+
+    public String getChangeManagerDataFromNickname(final String nickname) {
+        return String.format("%s님으로 방장이 변경되었습니다.", nickname);
+    }
 }

--- a/domain/mysql/src/main/java/kr/co/pawpaw/mysql/pet/domain/PetType.java
+++ b/domain/mysql/src/main/java/kr/co/pawpaw/mysql/pet/domain/PetType.java
@@ -14,7 +14,7 @@ public enum PetType {
     LIZARD("도마뱀"),
     FROG("개구리");
 
-    private String koreanName;
+    private final String koreanName;
 
     PetType(final String koreanName) {
         this.koreanName = koreanName;


### PR DESCRIPTION
Fix: 채팅방 메시지 유형 추가(INVITE, CHANGE_MANAGER) 및 채팅방 인원 초대 및 방장 위임시 메시지 전송

1. INVITE 유형 메시지는 data는 초대된 유저의 닉네임을 포함한 메시지
    a. data 예시) '<초대된 유저의 닉네임> 님이 초대되었습니다.'
    
2. CHANGE_MANAGER 유형의 메시지는 data는 위임된 방장의 닉네임을 포함한 메시지
    b. data 예시) '<위임된 방장의 닉네임> 님으로 방장이 변경되었습니다.'