### PR TITLE
[fix] 게시글 검색 로직 수정, 페이지 시작 번호 수정

### DIFF
--- a/api/src/main/java/kr/co/pawpaw/api/controller/board/BoardRestController.java
+++ b/api/src/main/java/kr/co/pawpaw/api/controller/board/BoardRestController.java
@@ -153,7 +153,7 @@ public class BoardRestController {
     public ResponseEntity<Slice<BoardListDto>> getSearchList(
             @AuthenticatedUserId UserId userId,
             @Parameter(description = "페이지 번호") @RequestParam(value = "pageNumber", defaultValue = "1") int pageNumber,
-            @Parameter(description = "한 페이지에 보여줄 게시글 수") @RequestParam(value = "pageSize", defaultValue = "4") int pageSize,
+            @Parameter(description = "한 페이지에 보여줄 게시글 수") @RequestParam(value = "pageSize", defaultValue = "100000", required = false) int pageSize,
             @Parameter(description = "검색어") @RequestParam(value = "query", required = false) String query) {
         Pageable pageable = PageRequest.of(pageNumber - 1, pageSize);
         return ResponseEntity.ok(boardService.searchBoardsByQuery(userId, pageable, query));

--- a/api/src/main/java/kr/co/pawpaw/api/controller/board/BoardRestController.java
+++ b/api/src/main/java/kr/co/pawpaw/api/controller/board/BoardRestController.java
@@ -111,9 +111,9 @@ public class BoardRestController {
     @GetMapping("/list")
     public ResponseEntity<Slice<BoardListDto>> getList(
             @AuthenticatedUserId UserId userId,
-            @Parameter(description = "페이지 번호") @RequestParam(value = "pageNumber", defaultValue = "0") int pageNumber,
+            @Parameter(description = "페이지 번호") @RequestParam(value = "pageNumber", defaultValue = "1") int pageNumber,
             @Parameter(description = "한 페이지에 보여줄 게시글 수") @RequestParam(value = "pageSize", defaultValue = "4") int pageSize) {
-        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Pageable pageable = PageRequest.of(pageNumber - 1, pageSize);
         return ResponseEntity.ok(boardService.getBoardListWithRepliesBy(userId, pageable));
     }
 
@@ -131,10 +131,10 @@ public class BoardRestController {
     @GetMapping("/{boardId}")
     public ResponseEntity<BoardListDto> getBoard(
             @AuthenticatedUserId UserId userId,
-            @Parameter(description = "페이지 번호") @RequestParam(value = "pageNumber", defaultValue = "0") int pageNumber,
+            @Parameter(description = "페이지 번호") @RequestParam(value = "pageNumber", defaultValue = "1") int pageNumber,
             @Parameter(description = "한 페이지에 보여줄 댓글 수") @RequestParam(value = "pageSize", defaultValue = "4") int pageSize,
             @PathVariable long boardId) {
-        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Pageable pageable = PageRequest.of(pageNumber - 1, pageSize);
         return ResponseEntity.ok(boardService.getBoardWithRepliesBy(boardId, userId, pageable));
     }
 
@@ -152,10 +152,10 @@ public class BoardRestController {
     @GetMapping("/search")
     public ResponseEntity<Slice<BoardListDto>> getSearchList(
             @AuthenticatedUserId UserId userId,
-            @Parameter(description = "페이지 번호") @RequestParam(value = "pageNumber", defaultValue = "0") int pageNumber,
+            @Parameter(description = "페이지 번호") @RequestParam(value = "pageNumber", defaultValue = "1") int pageNumber,
             @Parameter(description = "한 페이지에 보여줄 게시글 수") @RequestParam(value = "pageSize", defaultValue = "4") int pageSize,
             @Parameter(description = "검색어") @RequestParam(value = "query", required = false) String query) {
-        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Pageable pageable = PageRequest.of(pageNumber - 1, pageSize);
         return ResponseEntity.ok(boardService.searchBoardsByQuery(userId, pageable, query));
     }
 
@@ -173,9 +173,9 @@ public class BoardRestController {
     @GetMapping("/myPage")
     public ResponseEntity<Slice<BoardListDto>> getMyFeed(
             @AuthenticatedUserId UserId userId,
-            @Parameter(description = "페이지 번호") @RequestParam(value = "pageNumber", defaultValue = "0") int pageNumber,
+            @Parameter(description = "페이지 번호") @RequestParam(value = "pageNumber", defaultValue = "1") int pageNumber,
             @Parameter(description = "한 페이지에 보여줄 게시글 수") @RequestParam(value = "pageSize", defaultValue = "4") int pageSize) {
-        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        Pageable pageable = PageRequest.of(pageNumber - 1, pageSize);
         return ResponseEntity.ok(boardService.getBoardListWithRepliesByUser_UserId(userId, pageable));
     }
 

--- a/api/src/main/java/kr/co/pawpaw/api/service/board/BoardService.java
+++ b/api/src/main/java/kr/co/pawpaw/api/service/board/BoardService.java
@@ -15,7 +15,6 @@ import kr.co.pawpaw.common.exception.user.NotFoundUserException;
 import kr.co.pawpaw.mysql.board.domain.Board;
 import kr.co.pawpaw.mysql.board.service.command.BoardCommand;
 import kr.co.pawpaw.mysql.board.service.query.BoardQuery;
-import kr.co.pawpaw.mysql.storage.domain.File;
 import kr.co.pawpaw.mysql.user.domain.User;
 import kr.co.pawpaw.mysql.user.domain.UserId;
 import kr.co.pawpaw.mysql.user.service.query.UserQuery;
@@ -31,6 +30,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -164,10 +164,11 @@ public class BoardService {
     @Transactional(readOnly = true)
     public Slice<BoardListDto> searchBoardsByQuery(UserId userId, Pageable pageable, String query) {
         userQuery.findByUserId(userId).orElseThrow(NotFoundUserException::new);
-        if (!StringUtils.hasText(query) || query.isBlank())
-            throw new BoardException.BoardSearchQueryException();
 
-        Slice<Board> boardListWithRepliesForSearch = boardQuery.searchBoardsByQuery(query, pageable);
+        if (!StringUtils.hasText(query) || query.isBlank()){
+            return new SliceImpl<>(Collections.emptyList(), pageable, false);
+        }
+        Slice<Board> boardListWithRepliesForSearch = boardQuery.getBoardListWithRepliesBySearch(query, pageable);
 
         List<BoardListDto> boardListDtos = getBoardListDtos(userId, pageable, boardListWithRepliesForSearch);
 

--- a/domain/mysql/src/main/java/kr/co/pawpaw/mysql/board/repository/BoardRepository.java
+++ b/domain/mysql/src/main/java/kr/co/pawpaw/mysql/board/repository/BoardRepository.java
@@ -1,17 +1,10 @@
 package kr.co.pawpaw.mysql.board.repository;
 
 import kr.co.pawpaw.mysql.board.domain.Board;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
-
-    @Query("SELECT b FROM Board b JOIN b.user u LEFT JOIN b.reply r WHERE (b.content) LIKE LOWER(CONCAT('%', :query, '%'))")
-    Slice<Board> searchBoardsByQuery(@Param("query") String query, Pageable pageable);
 
     @EntityGraph(attributePaths = "fileUrls")
     Board findBoardWithFileUrlsById(Long id);

--- a/domain/mysql/src/main/java/kr/co/pawpaw/mysql/board/service/query/BoardQuery.java
+++ b/domain/mysql/src/main/java/kr/co/pawpaw/mysql/board/service/query/BoardQuery.java
@@ -32,8 +32,8 @@ public class BoardQuery {
     public Slice<Board> getBoardListWithRepliesByUser_UserId(Pageable pageable, UserId userId){
         return boardCustomRepository.getBoardListWithRepliesByUser_UserId(pageable, userId);
     }
-    public Slice<Board> searchBoardsByQuery(@Param("query") String query, Pageable pageable){
-        return boardRepository.searchBoardsByQuery(query, pageable);
+    public Slice<Board> getBoardListWithRepliesBySearch(@Param("query") String query, Pageable pageable){
+        return boardCustomRepository.getBoardListWithRepliesBySearch(pageable, query);
     }
     public Board findBoardWithFileUrlsById(@Param("id") Long id){
         return boardRepository.findBoardWithFileUrlsById(id);


### PR DESCRIPTION
1.게시글 검색 로직을 JPQL에서 querydsl 코드로 수정
2.검색어를 입력하지 않았을때 빈 배열을 반환하도록 수정
3.페이지가 0이 아닌 1부터 시작하도록 수정
